### PR TITLE
Add recording range to detail view & small enhancements

### DIFF
--- a/explore.js
+++ b/explore.js
@@ -458,6 +458,21 @@ function showDetailView(obj) {
   showDetailViewForId(probeId);
 }
 
+function linkedProbeType(type) {
+  const sourceDocs = "https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/";
+  const links = {
+    environment: sourceDocs + "data/environment.html",
+    histogram: sourceDocs + "collection/histograms.html",
+    scalar: sourceDocs + "collection/scalars.html",
+    event: sourceDocs + "collection/events.html",
+  };
+
+  if (type in links) {
+    return `<a href="${links[type]}">${type}</a>`;
+  }
+  return type;
+}
+
 function showDetailViewForId(probeId) {
   const last = array => array[array.length - 1];
 
@@ -466,7 +481,7 @@ function showDetailViewForId(probeId) {
 
   // Core probe data.
   $('#detail-probe-name').text(probe.name);
-  $('#detail-probe-type').text(probe.type);
+  $('#detail-probe-type').html(linkedProbeType(probe.type));
   const state = probe.history[channel][0];
   $('#detail-recording-type').text(state.optout ? "release" : "prerelease");
   $('#detail-description').text(state.description);

--- a/explore.js
+++ b/explore.js
@@ -314,7 +314,7 @@ function friendlyRecordingRange(firstVersion, expiry) {
   if (expiry == "never") {
     return `from ${firstVersion}`;
   }
-  return `${firstVersion} to ${shortVersion(expiry)}`;
+  return `${firstVersion} to ${parseInt(shortVersion(expiry)) - 1}`;
 }
 
 function friendlyRecordingRangeForState(state, channel) {

--- a/explore.js
+++ b/explore.js
@@ -222,10 +222,17 @@ function filterMeasurements() {
           case "new_in":
             var versions = getVersionRange(channel, m.revisions);
             return versions.first == versionNum;
+          case "is_expired":
+            var versions = getVersionRange(channel, m.revisions);
+            var expires = m.expiry_version;
+            return (versions.first <= versionNum) && (versions.last >= versionNum) &&
+                   (expires != "never") && (parseInt(expires) <= versionNum);
           default:
             throw "Yuck, unknown selector.";
         }
       });
+    } else if (version_constraint == "is_expired") {
+      history = history.filter(m => m.expiry_version != "never");
     }
 
     // Filter for text search.
@@ -408,7 +415,7 @@ function loadURIData() {
 
   if (params.has("constraint")) {
     let val = params.get("constraint");
-    if (["is_in", "new_in"].includes(val)) {
+    if (["is_in", "new_in", "is_expired"].includes(val)) {
       $("#select_constraint").val(val);
     }
   }

--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
         <tr><td>Kind:</td><td id="detail-kind"></td></tr>
         <tr><td>Keyed:</td><td id="detail-keyed"></td></tr>
         <tr><td>Bug numbers:</td><td id="detail-bug-numbers"></td></tr>
+        <tr><td>Recorded in versions:</td><td id="detail-recording-range"></td></tr>
         <tr><td>Recorded in processes:</td><td id="detail-processes"></td></tr>
         <tr><td>C++ guard:</td><td id="detail-cpp-guard"></td></tr>
         <tr><td>Bucket count:</td><td id="detail-histogram-bucket-count"></td></tr>

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
           <select class="form-control ml-2 mr-2" id="select_constraint">
             <option value="is_in" selected="selected">recorded</option>
             <option value="new_in">new</option>
+            <option value="is_expired" selected="selected">expired</option>
           </select>
           in version
           <select class="form-control ml-2 mr-2" id="select_version">

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
             <a class="nav-link" href="stats.html">Stats</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://github.com/georgf/fx-data-explorer/issues/new" target="_blank">File a bug</a>
+            <a class="nav-link" href="https://github.com/mozilla/probe-dictionary/issues/new" target="_blank">File a bug</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
- Add what versions a probe is recorded in to the detail view (part of #19).
- Make the "file a bug" link point to the new mozilla repository location.
- Add documentation links for probe types (histograms, scalars, ...) to the detail view.