### PR TITLE
Drop the ".json" extension from general.json and revisions.json

### DIFF
--- a/explore.js
+++ b/explore.js
@@ -41,8 +41,8 @@ $(document).ready(function() {
   mark("document ready");
 
   var loads = [
-    promiseGetJSON("firefox/general.json"),
-    promiseGetJSON("firefox/revisions.json"),
+    promiseGetJSON("firefox/general"),
+    promiseGetJSON("firefox/revisions"),
     promiseGetJSON("firefox/all/main/all_probes"),
     promiseGetJSON("environment.json", ""),
     promiseGetJSON("other_fields.json", ""),

--- a/stats.js
+++ b/stats.js
@@ -13,7 +13,7 @@ function mark(marker) {
 }
 
 function promiseGetJSON(file) {
-  var base_uri = "https://analysis-output.telemetry.mozilla.org/probe-scraper/data/";
+  var base_uri = "https://analysis-output.telemetry.mozilla.org/probe-scraper/data-rest/";
 
   return new Promise(resolve => {
     $.ajax({
@@ -32,9 +32,9 @@ $(document).ready(function() {
   mark("document ready");
 
   var loads = [
-    promiseGetJSON("general.json"),
-    promiseGetJSON("revisions.json"),
-    promiseGetJSON("probes.json"),
+    promiseGetJSON("firefox/general"),
+    promiseGetJSON("firefox/revisions"),
+    promiseGetJSON("firefox/all/main/all_probes"),
   ];
 
   Promise.all(loads).then(values => {


### PR DESCRIPTION
This additionally fixes the "stats" page who was using the old API.

Please note that this should be merged after the mozilla/probe-scraper#36 lands and the new files are produced, otherwise the page will break.