### PR TITLE
Add "sec" and "gfx" data to the environment

### DIFF
--- a/environment.json
+++ b/environment.json
@@ -3364,5 +3364,1076 @@
     },
     "name": "system.hdd.system.revision",
     "type": "environment"
+  },
+  "environment/system.gfx.D2DEnabled": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not Direct2D is enabled. This is Windows only.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not Direct2D is enabled. This is Windows only.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not Direct2D is enabled. This is Windows only.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.D2DEnabled",
+    "type": "environment"
+  },
+  "environment/system.gfx.DWriteEnabled": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not DirectWrite is enabled. This is Windows only.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not DirectWrite is enabled. This is Windows only.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not DirectWrite is enabled. This is Windows only.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.DWriteEnabled",
+    "type": "environment"
+  },
+  "environment/system.gfx.ContentBackend": {
+    "history": {
+      "release": [
+        {
+          "description": "The name of the content backend.",
+          "bug_numbers": [1302240],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "51",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name of the content backend.",
+          "bug_numbers": [1302240],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "51",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name of the content backend.",
+          "bug_numbers": [1302240],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "51",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.ContentBackend",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters.description": {
+    "history": {
+      "release": [
+        {
+          "description": "The name of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters.description",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters.vendorID": {
+    "history": {
+      "release": [
+        {
+          "description": "The vendor ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The vendor ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The vendor ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters.vendorID",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters.deviceID": {
+    "history": {
+      "release": [
+        {
+          "description": "The device ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The device ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The device ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters.deviceID",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters.subsysID": {
+    "history": {
+      "release": [
+        {
+          "description": "The subsystem ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The subsystem ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The subsystem ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters.subsysID",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters.RAM": {
+    "history": {
+      "release": [
+        {
+          "description": "The amount of onboard RAM, in MB, of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The amount of onboard RAM, in MB, of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The amount of onboard RAM, in MB, of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters.RAM",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters.driver": {
+    "history": {
+      "release": [
+        {
+          "description": "The driver of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The driver of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The driver of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters.driver",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters.driverVersion": {
+    "history": {
+      "release": [
+        {
+          "description": "The driver version of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The driver version of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The driver version of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters.driverVersion",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters.driverDate": {
+    "history": {
+      "release": [
+        {
+          "description": "The driver date of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The driver date of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The driver date of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters.driverDate",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters.isGPU2Active": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the second GFX adapter is active. Only available on the second GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the second GFX adapter is active. Only available on the second GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the second GFX adapter is active. Only available on the second GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters.isGPU2Active",
+    "type": "environment"
+  },
+  "environment/system.gfx.monitors.screenWidth": {
+    "history": {
+      "release": [
+        {
+          "description": "The width of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The width of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The width of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.monitors.screenWidth",
+    "type": "environment"
+  },
+  "environment/system.gfx.monitors.screenHeight": {
+    "history": {
+      "release": [
+        {
+          "description": "The height of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The height of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The height of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.monitors.screenHeight",
+    "type": "environment"
+  },
+  "environment/system.gfx.monitors.refreshRate": {
+    "history": {
+      "release": [
+        {
+          "description": "The refresh rate of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The refresh rate of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The refresh rate of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.monitors.refreshRate",
+    "type": "environment"
+  },
+  "environment/system.gfx.monitors.pseudoDisplay": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the monitor is a pseudo display.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the monitor is a pseudo display.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the monitor is a pseudo display.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.monitors.pseudoDisplay",
+    "type": "environment"
+  },
+  "environment/system.gfx.features.compositor": {
+    "history": {
+      "release": [
+        {
+          "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.features.compositor",
+    "type": "environment"
+  },
+  "environment/system.gfx.features.*.status": {
+    "history": {
+      "release": [
+        {
+          "description": "The status of the compositor's backend. The following statuses are supported: 'unused' if this feature has not been requested, 'unavailable' if OS version or restriction prevents use, 'blocked' if an internal condition (such as safe mode) prevents use, 'blacklisted' if blocked due to a blacklist restriction, 'disabled' if user explicitly disabled this default feature, 'failed' if the feature failed to initialize and 'available' if user has this feature available by default.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The status of the compositor's backend. The following statuses are supported: 'unused' if this feature has not been requested, 'unavailable' if OS version or restriction prevents use, 'blocked' if an internal condition (such as safe mode) prevents use, 'blacklisted' if blocked due to a blacklist restriction, 'disabled' if user explicitly disabled this default feature, 'failed' if the feature failed to initialize and 'available' if user has this feature available by default.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The status of the compositor's backend. The following statuses are supported: 'unused' if this feature has not been requested, 'unavailable' if OS version or restriction prevents use, 'blocked' if an internal condition (such as safe mode) prevents use, 'blacklisted' if blocked due to a blacklist restriction, 'disabled' if user explicitly disabled this default feature, 'failed' if the feature failed to initialize and 'available' if user has this feature available by default.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.features.*.status",
+    "type": "environment"
+  },
+  "environment/system.gfx.features.*.version": {
+    "history": {
+      "release": [
+        {
+          "description": "The name feature's version.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name feature's version.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name feature's version.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.features.*.version",
+    "type": "environment"
+  },
+  "environment/system.gfx.features.*.warp": {
+    "history": {
+      "release": [
+        {
+          "description": "The name feature's warp status. Only valid for D2D11.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name feature's warp status. Only valid for D2D11.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name feature's warp status. Only valid for D2D11.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.features.*.warp",
+    "type": "environment"
+  },
+  "environment/system.gfx.features.*.textureSharing": {
+    "history": {
+      "release": [
+        {
+          "description": "The name feature's texture sharing status. Only valid for D2D11.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name feature's texture sharing status. Only valid for D2D11.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name feature's texture sharing status. Only valid for D2D11.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.features.*.textureSharing",
+    "type": "environment"
   }
 }

--- a/environment.json
+++ b/environment.json
@@ -2600,6 +2600,57 @@
     "name": "system.isWow64",
     "type": "environment"
   },
+  "environment/system.appleModelId": {
+    "history": {
+      "release": [
+        {
+          "description": "The model IDs for Apple desktop devices. This is Mac only.",
+          "bug_numbers": [1409468],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "57",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The model IDs for Apple desktop devices. This is Mac only.",
+          "bug_numbers": [1409468],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "57",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The model IDs for Apple desktop devices. This is Mac only.",
+          "bug_numbers": [1409468],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "58",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.appleModelId",
+    "type": "environment"
+  },
   "environment/system.os.name": {
     "history": {
       "release": [
@@ -4287,7 +4338,7 @@
     "history": {
       "release": [
         {
-          "description": "The name feature's version.",
+          "description": "The feature's version.",
           "bug_numbers": [1179051],
           "details": {
             "kind": "number"
@@ -4302,7 +4353,7 @@
       ],
       "beta": [
         {
-          "description": "The name feature's version.",
+          "description": "The feature's version.",
           "bug_numbers": [1179051],
           "details": {
             "kind": "number"
@@ -4317,7 +4368,7 @@
       ],
       "nightly": [
         {
-          "description": "The name feature's version.",
+          "description": "The feature's version.",
           "bug_numbers": [1179051],
           "details": {
             "kind": "number"
@@ -4338,7 +4389,7 @@
     "history": {
       "release": [
         {
-          "description": "The name feature's warp status. Only valid for D2D11.",
+          "description": "The feature's warp status. Only valid for D2D11.",
           "bug_numbers": [1179051],
           "details": {
             "kind": "boolean"
@@ -4353,7 +4404,7 @@
       ],
       "beta": [
         {
-          "description": "The name feature's warp status. Only valid for D2D11.",
+          "description": "The feature's warp status. Only valid for D2D11.",
           "bug_numbers": [1179051],
           "details": {
             "kind": "boolean"
@@ -4368,7 +4419,7 @@
       ],
       "nightly": [
         {
-          "description": "The name feature's warp status. Only valid for D2D11.",
+          "description": "The feature's warp status. Only valid for D2D11.",
           "bug_numbers": [1179051],
           "details": {
             "kind": "boolean"
@@ -4389,7 +4440,7 @@
     "history": {
       "release": [
         {
-          "description": "The name feature's texture sharing status. Only valid for D2D11.",
+          "description": "The feature's texture sharing status. Only valid for D2D11.",
           "bug_numbers": [1179051],
           "details": {
             "kind": "boolean"
@@ -4404,7 +4455,7 @@
       ],
       "beta": [
         {
-          "description": "The name feature's texture sharing status. Only valid for D2D11.",
+          "description": "The feature's texture sharing status. Only valid for D2D11.",
           "bug_numbers": [1179051],
           "details": {
             "kind": "boolean"
@@ -4419,7 +4470,7 @@
       ],
       "nightly": [
         {
-          "description": "The name feature's texture sharing status. Only valid for D2D11.",
+          "description": "The feature's texture sharing status. Only valid for D2D11.",
           "bug_numbers": [1179051],
           "details": {
             "kind": "boolean"
@@ -4434,6 +4485,159 @@
       ]
     },
     "name": "system.gfx.features.*.textureSharing",
+    "type": "environment"
+  },
+  "environment/system.sec.antivirus": {
+    "history": {
+      "release": [
+        {
+          "description": "The name of the registered antivirus software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name of the registered antivirus software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name of the registered antivirus software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.sec.antivirus",
+    "type": "environment"
+  },
+  "environment/system.sec.antispyware": {
+    "history": {
+      "release": [
+        {
+          "description": "The name of the registered antispyware software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name of the registered antispyware software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name of the registered antispyware software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.sec.antispyware",
+    "type": "environment"
+  },
+  "environment/system.sec.firewall": {
+    "history": {
+      "release": [
+        {
+          "description": "The name of the registered firewall software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name of the registered firewall software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name of the registered firewall software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.sec.firewall",
     "type": "environment"
   }
 }


### PR DESCRIPTION
I tried this locally and the list loads correctly. There are, however, a few design decisions to consider:

- The "gfx.monitors" data is an array, each entry has some properties. I identified each property as `environment/system.gfx.monitors.screenWidth` but `environment/system.gfx.monitors[*].screenWidth` might be a better option.
- Similarly, `environment/system.gfx.features` can have sub-objects, all with the same properties. I identified them like e.g. `environment/system.gfx.features.*.textureSharing`.
