### PR TITLE
Merge back upstream changes from telemetry-dashboard repo

### DIFF
--- a/environment.json
+++ b/environment.json
@@ -2651,6 +2651,57 @@
     "name": "system.isWow64",
     "type": "environment"
   },
+  "environment/system.appleModelId": {
+    "history": {
+      "release": [
+        {
+          "description": "The model IDs for Apple desktop devices. This is Mac only.",
+          "bug_numbers": [1409468],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "57",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The model IDs for Apple desktop devices. This is Mac only.",
+          "bug_numbers": [1409468],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "57",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The model IDs for Apple desktop devices. This is Mac only.",
+          "bug_numbers": [1409468],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "58",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.appleModelId",
+    "type": "environment"
+  },
   "environment/system.os.name": {
     "history": {
       "release": [
@@ -3414,6 +3465,3372 @@
       ]
     },
     "name": "system.hdd.system.revision",
+    "type": "environment"
+  },
+  "environment/system.gfx.D2DEnabled": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not Direct2D is enabled. This is Windows only.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not Direct2D is enabled. This is Windows only.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not Direct2D is enabled. This is Windows only.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.D2DEnabled",
+    "type": "environment"
+  },
+  "environment/system.gfx.DWriteEnabled": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not DirectWrite is enabled. This is Windows only.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not DirectWrite is enabled. This is Windows only.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not DirectWrite is enabled. This is Windows only.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.DWriteEnabled",
+    "type": "environment"
+  },
+  "environment/system.gfx.ContentBackend": {
+    "history": {
+      "release": [
+        {
+          "description": "The name of the content backend.",
+          "bug_numbers": [1302240],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "51",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name of the content backend.",
+          "bug_numbers": [1302240],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "51",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name of the content backend.",
+          "bug_numbers": [1302240],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "51",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.ContentBackend",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters[index].description": {
+    "history": {
+      "release": [
+        {
+          "description": "The name of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters[index].description",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters[index].vendorID": {
+    "history": {
+      "release": [
+        {
+          "description": "The vendor ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The vendor ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The vendor ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters[index].vendorID",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters[index].deviceID": {
+    "history": {
+      "release": [
+        {
+          "description": "The device ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The device ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The device ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters[index].deviceID",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters[index].subsysID": {
+    "history": {
+      "release": [
+        {
+          "description": "The subsystem ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The subsystem ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The subsystem ID of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters[index].subsysID",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters[index].RAM": {
+    "history": {
+      "release": [
+        {
+          "description": "The amount of onboard RAM, in MB, of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The amount of onboard RAM, in MB, of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The amount of onboard RAM, in MB, of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters[index].RAM",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters[index].driver": {
+    "history": {
+      "release": [
+        {
+          "description": "The driver of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The driver of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The driver of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters[index].driver",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters[index].driverVersion": {
+    "history": {
+      "release": [
+        {
+          "description": "The driver version of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The driver version of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The driver version of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters[index].driverVersion",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters[index].driverDate": {
+    "history": {
+      "release": [
+        {
+          "description": "The driver date of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The driver date of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The driver date of the GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters[index].driverDate",
+    "type": "environment"
+  },
+  "environment/system.gfx.adapters[index].isGPU2Active": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the second GFX adapter is active. Only available on the second GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the second GFX adapter is active. Only available on the second GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the second GFX adapter is active. Only available on the second GFX adapter.",
+          "bug_numbers": [1122052],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.adapters[index].isGPU2Active",
+    "type": "environment"
+  },
+  "environment/system.gfx.monitors[index].screenWidth": {
+    "history": {
+      "release": [
+        {
+          "description": "The width of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The width of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The width of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.monitors[index].screenWidth",
+    "type": "environment"
+  },
+  "environment/system.gfx.monitors[index].screenHeight": {
+    "history": {
+      "release": [
+        {
+          "description": "The height of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The height of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The height of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.monitors[index].screenHeight",
+    "type": "environment"
+  },
+  "environment/system.gfx.monitors[index].refreshRate": {
+    "history": {
+      "release": [
+        {
+          "description": "The refresh rate of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The refresh rate of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The refresh rate of the monitor.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.monitors[index].refreshRate",
+    "type": "environment"
+  },
+  "environment/system.gfx.monitors[index].pseudoDisplay": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the monitor is a pseudo display.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the monitor is a pseudo display.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the monitor is a pseudo display.",
+          "bug_numbers": [1175005],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.monitors[index].pseudoDisplay",
+    "type": "environment"
+  },
+  "environment/system.gfx.features.compositor": {
+    "history": {
+      "release": [
+        {
+          "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name of the compositor. This is one of 'd3d9', 'd3d11', 'opengl', 'basic', or 'none' ('none' indicates no compositors have been created).",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.features.compositor",
+    "type": "environment"
+  },
+  "environment/system.gfx.features[key].status": {
+    "history": {
+      "release": [
+        {
+          "description": "The status of the compositor's backend. The following statuses are supported: 'unused' if this feature has not been requested, 'unavailable' if OS version or restriction prevents use, 'blocked' if an internal condition (such as safe mode) prevents use, 'blacklisted' if blocked due to a blacklist restriction, 'disabled' if user explicitly disabled this default feature, 'failed' if the feature failed to initialize and 'available' if user has this feature available by default.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The status of the compositor's backend. The following statuses are supported: 'unused' if this feature has not been requested, 'unavailable' if OS version or restriction prevents use, 'blocked' if an internal condition (such as safe mode) prevents use, 'blacklisted' if blocked due to a blacklist restriction, 'disabled' if user explicitly disabled this default feature, 'failed' if the feature failed to initialize and 'available' if user has this feature available by default.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The status of the compositor's backend. The following statuses are supported: 'unused' if this feature has not been requested, 'unavailable' if OS version or restriction prevents use, 'blocked' if an internal condition (such as safe mode) prevents use, 'blacklisted' if blocked due to a blacklist restriction, 'disabled' if user explicitly disabled this default feature, 'failed' if the feature failed to initialize and 'available' if user has this feature available by default.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.features[key].status",
+    "type": "environment"
+  },
+  "environment/system.gfx.features[key].version": {
+    "history": {
+      "release": [
+        {
+          "description": "The feature's version.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The feature's version.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The feature's version.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.features[key].version",
+    "type": "environment"
+  },
+  "environment/system.gfx.features[key].warp": {
+    "history": {
+      "release": [
+        {
+          "description": "The feature's warp status. Only valid for D2D11.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The feature's warp status. Only valid for D2D11.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The feature's warp status. Only valid for D2D11.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.features[key].warp",
+    "type": "environment"
+  },
+  "environment/system.gfx.features[key].textureSharing": {
+    "history": {
+      "release": [
+        {
+          "description": "The feature's texture sharing status. Only valid for D2D11.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The feature's texture sharing status. Only valid for D2D11.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The feature's texture sharing status. Only valid for D2D11.",
+          "bug_numbers": [1179051],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.gfx.features[key].textureSharing",
+    "type": "environment"
+  },
+  "environment/system.sec.antivirus": {
+    "history": {
+      "release": [
+        {
+          "description": "The name of the registered antivirus software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name of the registered antivirus software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name of the registered antivirus software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.sec.antivirus",
+    "type": "environment"
+  },
+  "environment/system.sec.antispyware": {
+    "history": {
+      "release": [
+        {
+          "description": "The name of the registered antispyware software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name of the registered antispyware software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name of the registered antispyware software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.sec.antispyware",
+    "type": "environment"
+  },
+  "environment/system.sec.firewall": {
+    "history": {
+      "release": [
+        {
+          "description": "The name of the registered firewall software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The name of the registered firewall software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The name of the registered firewall software. Windows only.",
+          "bug_numbers": [1418131],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "59",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "system.sec.firewall",
+    "type": "environment"
+  },
+  "environment/experiments[id].branch": {
+    "history": {
+      "release": [
+        {
+          "description": "The branch the client is enrolled in.",
+          "bug_numbers": [1348748],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "53",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The branch the client is enrolled in.",
+          "bug_numbers": [1348748],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "53",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The branch the client is enrolled in.",
+          "bug_numbers": [1348748],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "55",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "experiments[id].branch",
+    "type": "environment"
+  },
+  "environment/experiments[id].type": {
+    "history": {
+      "release": [
+        {
+          "description": "The specific type of the experiment.",
+          "bug_numbers": [1376599],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "55",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The specific type of the experiment.",
+          "bug_numbers": [1376599],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "55",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The specific type of the experiment.",
+          "bug_numbers": [1376599],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "56",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "experiments[id].type",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].version": {
+    "history": {
+      "release": [
+        {
+          "description": "The version of the add-on. This field is available at startup.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The version of the add-on. This field is available at startup.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The version of the add-on. This field is available at startup.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].version",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].scope": {
+    "history": {
+      "release": [
+        {
+          "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Indicates what scope the add-on is installed in, per profile, user, system, or application. This field is available at startup.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].scope",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].type": {
+    "history": {
+      "release": [
+        {
+          "description": "The type of the add-on. This field is available at startup.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The type of the add-on. This field is available at startup.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The type of the add-on. This field is available at startup.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].type",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].updateDay": {
+    "history": {
+      "release": [
+        {
+          "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The day the add-on was last updated. This field is optional, but available at startup if present.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].updateDay",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].isSystem": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
+          "bug_numbers": [1232222],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "47",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
+          "bug_numbers": [1232222],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "47",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the add-on is a system add-on. This field is available at startup.",
+          "bug_numbers": [1232222],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "47",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].isSystem",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].isWebExtension": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
+          "bug_numbers": [1357460],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "54",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
+          "bug_numbers": [1357460],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "54",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the add-on is a WebExtension add-on. This field is available at startup.",
+          "bug_numbers": [1357460],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "55",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].isWebExtension",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].multiprocessCompatible": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
+          "bug_numbers": [1357460],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "54",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
+          "bug_numbers": [1357460],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "54",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the add-on is a compatible with e10s. Since Firefox 61, this is always true. This field is available at startup.",
+          "bug_numbers": [1357460],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "54",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].multiprocessCompatible",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].blocklisted": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the add-on appears in the blocklist. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].blocklisted",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].description": {
+    "history": {
+      "release": [
+        {
+          "description": "The add-on description, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The add-on description, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The add-on description, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].description",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].name": {
+    "history": {
+      "release": [
+        {
+          "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The add-on name, limited to 100 characters. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].name",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].userDisabled": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the user disabled the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].userDisabled",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].appDisabled": {
+    "history": {
+      "release": [
+        {
+          "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "True if this add-on cannot be used in the application based on version compatibility, dependencies, and blocklisting. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].appDisabled",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].foreignInstall": {
+    "history": {
+      "release": [
+        {
+          "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "True or false depending on whether the add-on is a third party add-on installation or not. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].foreignInstall",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].hasBinaryComponents": {
+    "history": {
+      "release": [
+        {
+          "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "True or false depending on whether the add-on has binary components. This is always false since Firefox 60. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].hasBinaryComponents",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].installDay": {
+    "history": {
+      "release": [
+        {
+          "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The days since epoch that the add-on was first installed. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].installDay",
+    "type": "environment"
+  },
+  "environment/addons.activeAddons[addonId].signedState": {
+    "history": {
+      "release": [
+        {
+          "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1062388],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1062388],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The state of the signature of the add-on. This field is only available after the 'sessionstore-windows-restored' topic is notified.",
+          "bug_numbers": [1062388],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeAddons[addonId].signedState",
+    "type": "environment"
+  },
+  "environment/addons.theme.id": {
+    "history": {
+      "release": [
+        {
+          "description": "The id of the theme.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The id of the theme.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The id of the theme.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.theme.id",
+    "type": "environment"
+  },
+  "environment/addons.theme.version": {
+    "history": {
+      "release": [
+        {
+          "description": "The version of the theme.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The version of the theme.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The version of the theme.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.theme.version",
+    "type": "environment"
+  },
+  "environment/addons.theme.scope": {
+    "history": {
+      "release": [
+        {
+          "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Indicates what scope the theme is installed in, per profile, user, system, or application.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.theme.scope",
+    "type": "environment"
+  },
+  "environment/addons.theme.updateDay": {
+    "history": {
+      "release": [
+        {
+          "description": "The day the theme was last updated.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The day the theme was last updated.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The day the theme was last updated.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.theme.updateDay",
+    "type": "environment"
+  },
+  "environment/addons.theme.blocklisted": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the theme appears in the blocklist.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the theme appears in the blocklist.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the theme appears in the blocklist.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.theme.blocklisted",
+    "type": "environment"
+  },
+  "environment/addons.theme.description": {
+    "history": {
+      "release": [
+        {
+          "description": "The theme description, limited to 100 characters.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The theme description, limited to 100 characters.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The theme description, limited to 100 characters.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.theme.description",
+    "type": "environment"
+  },
+  "environment/addons.theme.name": {
+    "history": {
+      "release": [
+        {
+          "description": "The theme name, limited to 100 characters.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The theme name, limited to 100 characters.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The theme name, limited to 100 characters.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.theme.name",
+    "type": "environment"
+  },
+  "environment/addons.theme.userDisabled": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the user disabled the theme.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the user disabled the theme.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the user disabled the theme.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.theme.userDisabled",
+    "type": "environment"
+  },
+  "environment/addons.theme.appDisabled": {
+    "history": {
+      "release": [
+        {
+          "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "True if this theme cannot be used in the application based on version compatibility, dependencies, and blocklisting.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.theme.appDisabled",
+    "type": "environment"
+  },
+  "environment/addons.theme.foreignInstall": {
+    "history": {
+      "release": [
+        {
+          "description": "True or false depending on whether the theme is a third party theme installation or not.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "True or false depending on whether the theme is a third party theme installation or not.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "True or false depending on whether the theme is a third party theme installation or not.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.theme.foreignInstall",
+    "type": "environment"
+  },
+  "environment/addons.theme.hasBinaryComponents": {
+    "history": {
+      "release": [
+        {
+          "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "True or false depending on whether the theme has binary components. This is always false since Firefox 60.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.theme.hasBinaryComponents",
+    "type": "environment"
+  },
+  "environment/addons.theme.installDay": {
+    "history": {
+      "release": [
+        {
+          "description": "The days since epoch that the theme was first installed.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The days since epoch that the theme was first installed.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The days since epoch that the theme was first installed.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.theme.installDay",
+    "type": "environment"
+  },
+  "environment/addons.activePlugins[index].version": {
+    "history": {
+      "release": [
+        {
+          "description": "The version of the plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The version of the plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The version of the plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activePlugins[index].version",
+    "type": "environment"
+  },
+  "environment/addons.activePlugins[index].updateDay": {
+    "history": {
+      "release": [
+        {
+          "description": "The day the plugin was last updated.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The day the plugin was last updated.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The day the plugin was last updated.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activePlugins[index].updateDay",
+    "type": "environment"
+  },
+  "environment/addons.activePlugins[index].blocklisted": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the plugin appears in the blocklist.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the plugin appears in the blocklist.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the plugin appears in the blocklist.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activePlugins[index].blocklisted",
+    "type": "environment"
+  },
+  "environment/addons.activePlugins[index].description": {
+    "history": {
+      "release": [
+        {
+          "description": "The plugin description, limited to 100 characters.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The plugin description, limited to 100 characters.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The plugin description, limited to 100 characters.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activePlugins[index].description",
+    "type": "environment"
+  },
+  "environment/addons.activePlugins[index].name": {
+    "history": {
+      "release": [
+        {
+          "description": "The plugin name, limited to 100 characters.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The plugin name, limited to 100 characters.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The plugin name, limited to 100 characters.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activePlugins[index].name",
+    "type": "environment"
+  },
+  "environment/addons.activePlugins[index].disabled": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the plugin is disabled.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the plugin is disabled.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the plugin is disabled.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activePlugins[index].disabled",
+    "type": "environment"
+  },
+  "environment/addons.activePlugins[index].clicktoplay": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not clicktoplay is enabled for this plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not clicktoplay is enabled for this plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not clicktoplay is enabled for this plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activePlugins[index].clicktoplay",
+    "type": "environment"
+  },
+  "environment/addons.activePlugins[index].mimeTypes": {
+    "history": {
+      "release": [
+        {
+          "description": "The list of mime types handled by this plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "Array<string>"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The list of mime types handled by this plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "Array<string>"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The list of mime types handled by this plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "Array<string>"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activePlugins[index].mimeTypes",
+    "type": "environment"
+  },
+  "environment/addons.activeGMPlugins[id].version": {
+    "history": {
+      "release": [
+        {
+          "description": "The version of the plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The version of the plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The version of the plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeGMPlugins[index].version",
+    "type": "environment"
+  },
+  "environment/addons.activeGMPlugins[index].userDisabled": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the user disabled the plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the user disabled the plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the user disabled the plugin.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeGMPlugins[index].userDisabled",
+    "type": "environment"
+  },
+  "environment/addons.activeGMPlugins[index].applyBackgroundUpdates": {
+    "history": {
+      "release": [
+        {
+          "description": "Whether or not the plugin automatically updates in background.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "Whether or not the plugin automatically updates in background.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "Whether or not the plugin automatically updates in background.",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "boolean"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.activeGMPlugins[index].applyBackgroundUpdates",
+    "type": "environment"
+  },
+  "environment/addons.persona": {
+    "history": {
+      "release": [
+        {
+          "description": "The id of the active persona (theme).",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "beta": [
+        {
+          "description": "The id of the active persona (theme).",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ],
+      "nightly": [
+        {
+          "description": "The id of the active persona (theme).",
+          "bug_numbers": [1122050],
+          "details": {
+            "kind": "string"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    },
+    "name": "addons.persona",
     "type": "environment"
   }
 }

--- a/explore.js
+++ b/explore.js
@@ -227,8 +227,8 @@ function showSearchOnlyFilters(show) {
     }
 
     var channel = $("#select_channel").val();
-    if (!["release", "beta", "nightly", "any"].includes(channel)) {
-      $("#select_channel").val("any");
+    if (!["release", "beta", "nightly"].includes(channel)) {
+      $("#select_channel").val("release");
     }
   }
 }
@@ -300,18 +300,18 @@ function renderProbeSearch() {
 }
 
 function filterMeasurements() {
-  var version_constraint = $("#select_constraint").val();
+  var versionConstraint = $("#select_constraint").val();
   var optout = $("#optout").prop("checked");
   var version = $("#select_version").val();
-  var selected_channel = $("#select_channel").val();
-  var text_search = $("#text_search").val();
-  var text_constraint = $("#search_constraint").val();
+  var selectedChannel = $("#select_channel").val();
+  var textSearch = $("#text_search").val();
+  var textConstraint = $("#search_constraint").val();
   var measurements = gProbeData;
 
   // Filter out by selected criteria.
   var filtered = {};
-  var channels = [selected_channel];
-  if (selected_channel == "any") {
+  var channels = [selectedChannel];
+  if (selectedChannel == "any") {
     channels = ["nightly", "beta", "release"];
   }
 
@@ -331,7 +331,7 @@ function filterMeasurements() {
       if (version != "any") {
         var versionNum = parseInt(version);
         history = history.filter(m => {
-          switch (version_constraint) {
+          switch (versionConstraint) {
             case "is_in":
               var versions = getVersionRange(channel, m.revisions);
               var expires = m.expiry_version;
@@ -349,16 +349,16 @@ function filterMeasurements() {
               throw "Yuck, unknown selector.";
           }
         });
-      } else if (version_constraint == "is_expired") {
+      } else if (versionConstraint == "is_expired") {
         history = history.filter(m => m.expiry_version != "never");
       }
 
       // Filter for text search.
-      if (text_search != "") {
-        var s = text_search.toLowerCase();
+      if (textSearch != "") {
+        var s = textSearch.toLowerCase();
         var test = (str) => str.toLowerCase().includes(s);
         history = history.filter(h => {
-          switch (text_constraint) {
+          switch (textConstraint) {
             case "in_name": return test(data.name);
             case "in_description": return test(h.description);
             case "in_any": return test(data.name) || test(h.description);
@@ -383,7 +383,7 @@ function filterMeasurements() {
 
 function renderVersions() {
   var select = $("#select_version");
-  var current_channel = $("#select_channel").val();
+  var currentChannel = $("#select_channel").val();
   var versions = new Set();
 
   $.each(gRevisionsData, (channel, revs) => {
@@ -431,28 +431,50 @@ function shortVersion(v) {
   return v.split(".")[0];
 }
 
-function friendlyRecordingRange(firstVersion, expiry) {
-  if (expiry == "never") {
+/**
+ * Return a human readable description of from when to when a probe is recorded.
+ * This can return "never", "from X to Y" or "from X" for non-expiring probes.
+ *
+ * @param history The history array of a probe for a channel.
+ * @param channel The Firefox channel this history is for.
+ * @param filterPrerelease Whether to filter out prerelease probes on the release channel.
+ */
+function friendlyRecordingRangeForHistory(history, channel, filterPrerelease) {
+  const last = array => array[array.length - 1];
+
+  // Optionally filter out prerelease probes on the release channel.
+  // This is used for the detail view, but not for the search results view.
+  if ((channel == "release") && filterPrerelease) {
+    history = history.filter(h => h.optout);
+  }
+
+  // The filtering might have left us with an empty recording history.
+  // This means we never recorded anything on this channel.
+  if (history.length == 0) {
+    return "never";
+  }
+
+  const expiry = last(history).expiry_version;
+  const latestVersion = Math.max.apply(null, Object.keys(gChannelInfo[channel].versions));
+  const firstVersion = getVersionRange(channel, last(history).revisions).first;
+  let lastVersion = getVersionRange(channel, history[0].revisions).last;
+
+  if (expiry == "never" && (lastVersion >= latestVersion)) {
     return `from ${firstVersion}`;
   }
-  return `${firstVersion} to ${parseInt(shortVersion(expiry)) - 1}`;
-}
 
-function friendlyRecordingRangeForState(state, channel) {
-  const firstVersion = getVersionRange(channel, state["revisions"]).first;
-  const expiry = state.expiry_version;
-  return friendlyRecordingRange(firstVersion, expiry);
-}
+  if (expiry != "never") {
+    const expiryVersion = parseInt(shortVersion(expiry));
+    if (lastVersion >= expiryVersion) {
+      lastVersion = expiryVersion - 1;
+    }
+  }
 
-function friendlyRecordingRangeForHistory(history, channel) {
-  const last = array => array[array.length - 1];
-  const firstVersion = getVersionRange(channel, history[0]["revisions"]).first;
-  const expiry = last(history).expiry_version;
-  return friendlyRecordingRange(firstVersion, expiry);
+  return `${firstVersion} to ${lastVersion}`;
 }
 
 function renderMeasurements(measurements) {
-  var selected_channel = $("#select_channel").val();
+  var selectedChannel = $("#select_channel").val();
   var container = $("#measurements");
   var items = [];
 
@@ -461,7 +483,7 @@ function renderMeasurements(measurements) {
     ["name", (d, h, c) => d.name],
     ["type", (d, h, c) => d.type],
     ["population", (d, h, c) => h.optout ? "release" : "prerelease"],
-    ["recorded", (d, h, c, history) => friendlyRecordingRangeForHistory(history, c)],
+    ["recorded", (d, h, c, history) => friendlyRecordingRangeForHistory(history, c, false)],
     // TODO: overflow should cut off
     ["description", (d, h, c) => escapeHtml(h.description)],
   ];
@@ -479,7 +501,7 @@ function renderMeasurements(measurements) {
     for (let [channel, history] of Object.entries(data.history)) {
       // TODO: Why do we include the following in the filtering stage? Fix this.
       // Only show channels that we should show now.
-      if ((selected_channel !== "any") && (channel !== selected_channel)) {
+      if ((selectedChannel !== "any") && (channel !== selectedChannel)) {
         continue;
       }
       if (channel == "aurora") {
@@ -488,11 +510,11 @@ function renderMeasurements(measurements) {
       // When not filtering by channel, it's confusing to show multiple rows for each probe (one for each channel).
       // The short-term hack here to improve this is to only show the release channel state.
       // TODO: solve this better.
-      if ((selected_channel === "any") && (channel !== "release")) {
+      if ((selectedChannel === "any") && (channel !== "release")) {
         continue;
       }
       // Don't show pre-release measurements for the release channel.
-      if (!history[0].optout && (channel == "release") && (selected_channel !== "any")) {
+      if (!history[0].optout && (channel == "release") && (selectedChannel !== "any")) {
         continue;
       }
 
@@ -593,10 +615,37 @@ function updateSearchParams(pushState = false) {
     params.detailView = gDetailViewId;
   }
 
+  if (params['search']=="") {
+    delete params.search;
+  }
+  if (params['searchtype']=="in_any") {
+    delete params.searchtype;
+  }
+  if (params['optout']==false) {
+    delete params.optout;
+  }
+  if (params['channel']=="any") {
+    delete params.channel;
+  }
+  if (params['constraint']=="is_in") {
+    delete params.constraint;
+  }
+  if (params['version']=="any") {
+    delete params.version;
+  }
+  if (params['view']=="search-results-view") {
+    delete params.view;
+  }
+
+  let queryString = "";
+  if (Object.keys(params).length) {
+    queryString = "?" + $.param(params);
+  }
+
   if (!pushState) {
-    window.history.replaceState("", "", "?" + $.param(params));
+    window.history.replaceState({}, "", queryString);
   } else {
-    window.history.pushState("", "", "?" + $.param(params));
+    window.history.pushState({}, "", queryString);
   }
 }
 
@@ -633,6 +682,7 @@ function findProbeIdFromCaseInsensitive(probeid) {
 }
 
 function getDatasetInfos(probeId, channel, state) {
+  const last = array => array[array.length - 1];
   // Available documentation.
   const dataDocs = {
     "longitudinal": "https://docs.telemetry.mozilla.org/concepts/choosing_a_dataset.html#longitudinal",
@@ -651,11 +701,7 @@ function getDatasetInfos(probeId, channel, state) {
       (probe.type == "simpleMeasurements" && ["number", "bool"].includes(state.details.kind))) {
     var versions = getVersionRange(channel, state.revisions);
     const distURL = getTelemetryDashboardURL('dist', probe.name, probe.type, channel, versions.first, versions.last);
-    const evoURL = getTelemetryDashboardURL('evo', probe.name, probe.type, channel, versions.first, versions.last);
-    datasetInfos.push("TMO dashboard: "
-                      + `<a href="${distURL}" target="_blank">distribution</a>`
-                      + ", "
-                      + `<a href="${evoURL}" target="_blank">evolution</a>`);
+    datasetInfos.push(`<a href="${distURL}" target="_blank">Measurements dashboard</a>`);
   }
 
   // Use counter dashboard links.
@@ -819,7 +865,7 @@ function showDetailViewForId(probeId, channel=$("#select_channel").val()) {
     if ((!history[0].optout && (ch == "release")) || (ch == "aurora")) {
       continue;
     }
-    rangeText.push(`${ch} ${friendlyRecordingRangeForHistory(history, ch)}`);
+    rangeText.push(`${ch} ${friendlyRecordingRangeForHistory(history, ch, true)}`);
   }
   $('#detail-recording-range').html(rangeText.join("<br/>"));
 
@@ -900,7 +946,7 @@ function getMeasurementCountsPerVersion() {
   let last = array => array[array.length - 1];
 
   let channel = $("#select_channel").val();
-  let version_constraint = $("#select_constraint").val();
+  let versionConstraint = $("#select_constraint").val();
 
   let perVersionCounts = {};
   for (let v of Object.keys(gChannelInfo[channel].versions)) {
@@ -911,18 +957,33 @@ function getMeasurementCountsPerVersion() {
     };
   }
 
+  function countProbe(data, k) {
+    if ((channel !== "release") || (k === "optout")) {
+      data[k] += 1;
+    }
+  }
+
   $.each(gProbeData, (id, data) => {
     let history = data.history[channel];
     if (!history) {
       return;
     }
 
-    switch (version_constraint) {
-      case "new_in": {
-        let oldest = last(history);
-        let versions = getVersionRange(channel, oldest.revisions);
-        let k = oldest.optout ? "optout" : "optin";
-        perVersionCounts[versions.first][k] += 1;
+    switch (versionConstraint) {
+      case "new_in": 
+      {
+        $.each(perVersionCounts, (version, data) => {
+          let recording = history.find(h => {
+            let ver = parseInt(version);
+            let versions = getVersionRange(channel, h.revisions);
+            return (ver == versions.first);
+          });
+          // If so, increase the count.
+          if (recording) {
+            let k = recording.optout ? "optout" : "optin";
+            countProbe(data, k);
+          }
+        });
         break;
       }
       case "is_in":
@@ -939,7 +1000,7 @@ function getMeasurementCountsPerVersion() {
           // If so, increase the count.
           if (recording) {
             let k = recording.optout ? "optout" : "optin";
-            data[k] += 1;
+            countProbe(data, k);
           }
         });
         break;
@@ -953,7 +1014,7 @@ function getMeasurementCountsPerVersion() {
           if ((versions.first <= versionNum) && (versions.last >= versionNum) &&
               (expires != "never") && (parseInt(expires) <= versionNum)) {
             let k = newest.optout ? "optout" : "optin";
-            data[k] += 1;
+            countProbe(data, k);
           }
         });
         break;
@@ -974,9 +1035,12 @@ function getMeasurementCountsPerVersion() {
 
 function renderProbeStats() {
   var data = getMeasurementCountsPerVersion();
+  var hasOptoutData = (data.find(item => item.optout > 0) !== undefined);
+  var hasOptinData = (data.find(item => item.optin > 0) !== undefined);
+
 
   let last = array => array[array.length - 1];
-  let version_constraint = $("#select_constraint").val();
+  let versionConstraint = $("#select_constraint").val();
 
   // Prepare data.
   var columns = ["optin", "optout"];
@@ -1012,7 +1076,7 @@ function renderProbeStats() {
       .rangeRound([height, 0]);
 
   var z = d3.scaleOrdinal()
-      .range(["#98abc5", "#d0743c"]);
+      .range(["#d0743c", "#98abc5"]);
 
   var stack = d3.stack();
 
@@ -1039,7 +1103,7 @@ function renderProbeStats() {
       .call(d3.axisBottom(x));
 
   var constraintText;
-  switch (version_constraint) {
+  switch (versionConstraint) {
     case "new_in": constraintText = "new"; break;
     case "is_in": constraintText = "recorded"; break;
     case "is_expired": constraintText = "expired"; break;
@@ -1057,8 +1121,16 @@ function renderProbeStats() {
       .attr("fill", "#000")
       .text("Count of " + constraintText + " probes");
 
+  var legendLabels = [];
+  if (hasOptinData) {
+    legendLabels.push("optin");
+  }
+  if (hasOptoutData) {
+    legendLabels.push("optout");
+  }
+  
   var legend = g.selectAll(".legend")
-    .data(columns.reverse())
+    .data(legendLabels.reverse())
     .enter().append("g")
       .attr("class", "legend")
       .attr("transform", function(d, i) { return "translate(0," + i * 20 + ")"; })

--- a/explore.js
+++ b/explore.js
@@ -16,6 +16,48 @@ var gDatasetMappings = null;
 var gView = null;
 var gDetailViewId = null;
 
+$(document)
+  .ready(function () {
+    // Permalink control
+    $(".permalink-control input")
+      .hide()
+      .focus(function () {
+        // Workaround for broken selection: http://stackoverflow.com/questions/5797539
+        var $this = $(this);
+        $this.select()
+          .mouseup(function () {
+            $this.unbind("mouseup");
+            return false;
+          });
+      });
+    $(".permalink-control button")
+      .click(function () {
+        var $this = $(this);
+        $.ajax({
+          url: "https://api-ssl.bitly.com/v3/shorten",
+          dataType: "json",
+          data: {
+            longUrl: window.location.href,
+            access_token: "48ecf90304d70f30729abe82dfea1dd8a11c4584",
+            format: "json"
+          },
+          success: function (response) {
+            var shortUrl = response.data.url;
+            if (shortUrl.indexOf(":") === 4) {
+              shortUrl = "https" + shortUrl.substring(4);
+            }
+            $this.parents(".permalink-control")
+              .find("input")
+              .show()
+              .val(shortUrl)
+              .focus();
+          },
+          async:false
+        });
+        document.execCommand('copy');
+      });
+  });
+
 function mark(marker) {
   if (performance.mark) {
     performance.mark(marker);

--- a/explorer.css
+++ b/explorer.css
@@ -8,6 +8,20 @@ body {
     margin-right: 2px;
 }
 
+.permalink-control button {
+    background: none;
+    cursor: pointer;
+    padding: 7.5px 8px;
+    line-height: 1.5;
+    color:rgba(255,255,255,.75);
+    font-weight: bold;
+    font-family: "Segoe UI", "Source Sans Pro", Calibri, Candara, Arial, sans-serif;
+}
+
+.permalink-control button:hover {
+    color : white;
+}
+
 #github-banner img {
     position: absolute;
     top: 0;

--- a/explorer.css
+++ b/explorer.css
@@ -8,6 +8,10 @@ body {
     margin-right: 2px;
 }
 
+.navbar-brand {
+    font-weight: bold;
+}
+
 .permalink-control button {
     background: none;
     cursor: pointer;
@@ -135,4 +139,23 @@ body {
 
 .hidden {
     display: none;
+}
+
+#detail-cpp-guard:empty:after, #detail-bug-numbers:empty:after {
+    content: "none";
+    font-style: italic;
+}
+
+.nav-item {
+    font-weight: bold;
+}
+
+th {
+    position: sticky;
+    top: -1px;
+    background-color: #ECECEC;
+}
+
+#detail-probe-name {
+    overflow-wrap: break-word;
 }

--- a/index.html
+++ b/index.html
@@ -51,6 +51,14 @@
           <li>
             <a class="nav-link" href="https://telemetry.mozilla.org/"><i class="fa fa-home"></i> Telemetry portal</a>
           </li>
+          <li>
+            <div class="permalink-control">
+              <div class="input-group">
+                <span class="input-group-btn"><button type="button" class="btn btn-default" title="Get Shortlink"><i class="fa fa-link"></i> Get Shortlink</button></span>
+                <input type="text" class="form-control">
+              </div>
+            </div>
+          </li>
         </ul>
         <div class="navbar-text my-lg-0" id="last-updated">
           Updated <span id="last-updated-date"></span>

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
   <!-- Font Awesome -->
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49796218-2"></script>
 </head>
 
 <body>
@@ -31,11 +32,11 @@
       <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <a class="navbar-brand" href="#">Probe dictionary</a>
+      <a class="navbar-brand" href="#">Probe Dictionary</a>
 
       <div class="collapse navbar-collapse" id="navbarCollapse">
         <ul class="navbar-nav mr-auto">
-          <li class="nav-item active">
+          <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#search-results-view" role="tab" aria-controls="search-results-view">
               <i class="fa fa-search"></i> Find probes <span class="sr-only">(current)</span>
             </a>
@@ -48,7 +49,7 @@
           <li class="nav-item">
             <a class="nav-link" href="https://github.com/mozilla/probe-dictionary/issues/new" target="_blank"><i class="fa fa-bug"></i> File a bug</a>
           </li>
-          <li>
+          <li class="nav-item">
             <a class="nav-link" href="https://telemetry.mozilla.org/"><i class="fa fa-home"></i> Telemetry portal</a>
           </li>
           <li>
@@ -146,11 +147,11 @@
 
   <div class="container-fluid hidden" id="probe-detail-view">
     <div id="detail-body">
-      <h2 id="detail-probe-name">Probe name</h2>
       <button type="button" class="close"
               aria-label="Close" id="close-detail-view">
         <span aria-hidden="true">&times;</span>
       </button>
+      <h2 id="detail-probe-name">Probe name</h2>
       <br />
       <br />
       <table class="table table-sm table-striped table-hover table-bordered border-0">
@@ -169,13 +170,13 @@
         <tr><td class="fit pr-2">Bug numbers:</td><td id="detail-bug-numbers" class="grow"></td></tr>
         <tr><td class="fit pr-2">Recorded in versions:</td><td id="detail-recording-range" class="grow"></td></tr>
         <tr><td class="fit pr-2">Recorded in processes:</td><td id="detail-processes" class="grow"></td></tr>
-        <tr><td class="fit pr-2">C++ guard:</td><td id="detail-cpp-guard" class="grow"></td></tr>
         <tr><td class="fit pr-2">Bucket count:</td><td id="detail-histogram-bucket-count" class="grow"></td></tr>
         <tr><td class="fit pr-2">Low:</td><td id="detail-histogram-low" class="grow"></td></tr>
         <tr><td class="fit pr-2">High:</td><td id="detail-histogram-high" class="grow"></td></tr>
         <tr><td class="fit pr-2">Methods:</td><td id="detail-event-methods" class="grow"></td></tr>
         <tr><td class="fit pr-2">Objects:</td><td id="detail-event-objects" class="grow"></td></tr>
         <tr><td class="fit pr-2">Extra keys:</td><td id="detail-event-extra-keys" class="grow"></td></tr>
+        <tr><td class="fit pr-2">C++ guard:</td><td id="detail-cpp-guard" class="grow"></td></tr>
       </table>
     </div>
   </div>
@@ -193,5 +194,6 @@
   <!-- JS: D3 Visualization -->
   <script src="https://d3js.org/d3.v4.min.js"></script>
 
+  <script src="../analytics/analytics.js"></script>
 </body>
 </html>


### PR DESCRIPTION
*(not needed to review during SF allhands)*

A first pass on merging back the upstream changes from the telemetry-dashboard repo.
We may have to do another smaller merge later when we know how to deploy this repo through TMO, but that should be much easier after this.