### PR TITLE
Merge in changes from mozilla/telemetry-dashboard

### DIFF
--- a/datasets.json
+++ b/datasets.json
@@ -89,6 +89,22 @@
     "main_summary": "session_restored",
     "longitudinal": "session_restored"
   },
+  "simpleMeasurements/selectProfile": {
+    "main_summary": "select_profile",
+    "longitudinal": "select_profile"
+  },
+  "simpleMeasurements/delayedStartupStarted": {
+    "main_summary": "delayed_startup_started",
+    "longitudinal": "delayed_startup_started"
+  },
+  "simpleMeasurements/delayedStartupFinished": {
+    "main_summary": "delayed_startup_finished",
+    "longitudinal": "delayed_startup_finished"
+  },
+  "simpleMeasurements/blankWindowShown": {
+    "main_summary": "blank_window_shown",
+    "longitudinal": "blank_window_shown"
+  },
   "simpleMeasurements/totalTime": {
     "main_summary": "total_time",
     "longitudinal": "total_time"

--- a/explore.js
+++ b/explore.js
@@ -16,47 +16,6 @@ var gDatasetMappings = null;
 var gView = null;
 var gDetailViewId = null;
 
-$(document)
-  .ready(function () {
-    // Permalink control
-    $(".permalink-control input")
-      .hide()
-      .focus(function () {
-        // Workaround for broken selection: http://stackoverflow.com/questions/5797539
-        var $this = $(this);
-        $this.select()
-          .mouseup(function () {
-            $this.unbind("mouseup");
-            return false;
-          });
-      });
-    $(".permalink-control button")
-      .click(function () {
-        var $this = $(this);
-        $.ajax({
-          url: "https://api-ssl.bitly.com/v3/shorten",
-          dataType: "json",
-          data: {
-            longUrl: window.location.href,
-            access_token: "48ecf90304d70f30729abe82dfea1dd8a11c4584",
-            format: "json"
-          },
-          success: function (response) {
-            var shortUrl = response.data.url;
-            if (shortUrl.indexOf(":") === 4) {
-              shortUrl = "https" + shortUrl.substring(4);
-            }
-            $this.parents(".permalink-control")
-              .find("input")
-              .show()
-              .val(shortUrl)
-              .focus();
-          },
-          async:false
-        });
-        document.execCommand('copy');
-      });
-  });
 
 function mark(marker) {
   if (performance.mark) {
@@ -99,56 +58,103 @@ $(document).ready(function() {
     promiseGetJSON("datasets.json", ""),
   ];
 
-  Promise.all(loads).then(values => {
-    mark("all json loaded");
-    [gGeneralData, gRevisionsData, gProbeData, gEnvironmentData, gSimpleMeasurementsData, gDatasetMappings] = values;
-
-    extractChannelInfo();
-    processOtherFieldData(gEnvironmentData);
-    processOtherFieldData(gSimpleMeasurementsData);
-    renderVersions();
-    loadURIData();
-    update();
-
-    mark("updated site");
-
-    // Tab change events.
-    $('a[data-toggle="tab"]').on('show.bs.tab', tabChange);
-    $('a[data-toggle="tab"]').on('shown.bs.tab', updateSearchParams);
-
-    // Search view events.
-    $("#select_constraint").change(update);
-    $("#select_version").change(update);
-    $("#select_version").keyup(update);
-    $("#select_channel").change(update);
-    $("#optout").change(update);
-    $("#search_constraint").change(update);
-    $(window).on('popstate', loadURIData);
-
-    var delaySearch = makeDelay(50);
-    $("#text_search").keyup(() => delaySearch(update));
-
-    // Add detail view events.
-    $(document).keyup(e => {
-      // Catch Escape key presses.
-      if ((e.which == 27) && gDetailViewId) {
-        hideDetailView();
-      }
-    });
-    $("#close-detail-view").click(() => {
-      hideDetailView();
-    });
-
-    // Add when the data was last updated.
-    let date = new Date(gGeneralData.lastUpdate);
-    $("#last-updated-date").text(date.toDateString());
-
-    $("#loading-overlay").addClass("hidden");
-    mark("done");
-  }, e => {
-    console.log("caught", e);
-  });
+  Promise.all(loads)
+         .then(values => initializePage(values))
+         .catch(e => console.log("caught", e));
 });
+
+function initializePage(values) {
+  mark("all json loaded");
+  [gGeneralData, gRevisionsData, gProbeData, gEnvironmentData, gSimpleMeasurementsData, gDatasetMappings] = values;
+
+  extractChannelInfo();
+  processOtherFieldData(gEnvironmentData);
+  processOtherFieldData(gSimpleMeasurementsData);
+  renderVersions();
+  loadURIData();
+  update();
+
+  mark("updated site");
+
+  // Tab change events.
+  $('a[data-toggle="tab"]').on('show.bs.tab', tabChange);
+  $('a[data-toggle="tab"]').on('shown.bs.tab', updateSearchParams);
+
+  // Search view events.
+  $("#select_constraint").change(update);
+  $("#select_version").change(update);
+  $("#select_version").keyup(update);
+  $("#select_channel").change(update);
+  $("#optout").change(update);
+  $("#search_constraint").change(update);
+  $(window).on('popstate', loadURIData);
+
+  var delaySearch = makeDelay(50);
+  $("#text_search").keyup(() => delaySearch(update));
+
+  // Add detail view events.
+  $(document).keyup(e => {
+    // Catch Escape key presses.
+    if ((e.which == 27) && gDetailViewId) {
+      hideDetailView();
+    }
+  });
+  $("#close-detail-view").click(() => {
+    hideDetailView();
+  });
+
+  // Add when the data was last updated.
+  let date = new Date(gGeneralData.lastUpdate);
+  $("#last-updated-date").text(date.toDateString());
+
+  $("#loading-overlay").addClass("hidden");
+
+  initializeShortlink();
+
+  mark("init done");
+}
+
+function initializeShortlink() {
+  $(".permalink-control input").hide().focus(function () {
+    // Workaround for broken selection: http://stackoverflow.com/questions/5797539
+    var $this = $(this);
+    $this.select().mouseup(function () {
+      $this.unbind("mouseup");
+      return false;
+    });
+  });
+
+  $(".permalink-control button").click(function () {
+    var $this = $(this);
+    $.ajax({
+      url: "https://api-ssl.bitly.com/v3/shorten",
+      dataType: "json",
+      data: {
+        longUrl: window.location.href,
+        access_token: "48ecf90304d70f30729abe82dfea1dd8a11c4584",
+        format: "json"
+      },
+      success: function (response) {
+        var shortUrl = response.data.url;
+        if (!shortUrl) {
+          console.error("failed to get shortUrl");
+          return;
+        }
+        if (shortUrl.indexOf(":") === 4) {
+          shortUrl = "https" + shortUrl.substring(4);
+        }
+        $this.parents(".permalink-control")
+          .find("input")
+          .show()
+          .val(shortUrl)
+          .focus();
+      },
+      async: false
+    });
+
+    document.execCommand('copy');
+  });
+}
 
 function extractChannelInfo() {
   var result = {};
@@ -431,6 +437,10 @@ function shortVersion(v) {
   return v.split(".")[0];
 }
 
+function getLatestVersion(channel) {
+  return Math.max(...Object.keys(gChannelInfo[channel].versions));
+}
+
 /**
  * Return a human readable description of from when to when a probe is recorded.
  * This can return "never", "from X to Y" or "from X" for non-expiring probes.
@@ -455,7 +465,7 @@ function friendlyRecordingRangeForHistory(history, channel, filterPrerelease) {
   }
 
   const expiry = last(history).expiry_version;
-  const latestVersion = Math.max.apply(null, Object.keys(gChannelInfo[channel].versions));
+  const latestVersion = getLatestVersion(channel);
   const firstVersion = getVersionRange(channel, last(history).revisions).first;
   let lastVersion = getVersionRange(channel, history[0].revisions).last;
 
@@ -465,12 +475,25 @@ function friendlyRecordingRangeForHistory(history, channel, filterPrerelease) {
 
   if (expiry != "never") {
     const expiryVersion = parseInt(shortVersion(expiry));
-    if (lastVersion >= expiryVersion) {
+    if ((lastVersion >= expiryVersion) || (lastVersion >= latestVersion)) {
       lastVersion = expiryVersion - 1;
     }
   }
 
   return `${firstVersion} to ${lastVersion}`;
+}
+
+function friendlyExpiryDescriptionForHistory(history, channel) {
+  let expiry = history[0].expiry_version || "never";
+  if (expiry == "never") {
+    return "never expires";
+  }
+
+  const expiryVersion = parseInt(shortVersion(expiry));
+  let latestVersion = getLatestVersion(channel);
+  let alreadyExpired = (latestVersion >= expiryVersion);
+
+  return `${alreadyExpired ? "stopped" : "will stop"} recording in ${expiry}`;
 }
 
 function renderMeasurements(measurements) {
@@ -479,13 +502,29 @@ function renderMeasurements(measurements) {
   var items = [];
 
   var rawColumns = [
-    ["", (d, h, c) => '<span class="btn btn-outline-secondary btn-sm">+<span>'],
-    ["name", (d, h, c) => d.name],
-    ["type", (d, h, c) => d.type],
-    ["population", (d, h, c) => h.optout ? "release" : "prerelease"],
-    ["recorded", (d, h, c, history) => friendlyRecordingRangeForHistory(history, c, false)],
+    ["", {
+      content: (d, h, c) => '<span class="btn btn-outline-secondary btn-sm">+<span>',
+    }],
+    ["name", {
+      content: (d, h, c) => d.name,
+    }],
+    ["type", {
+      content: (d, h, c) => d.type,
+    }],
+    ["population", {
+      content: (d, h, c) => h.optout ? "release" : "prerelease",
+      tooltip: "Whether this probe collected on Firefox release or only on " +
+               "prerelease channels."
+    }],
+    ["recorded", {
+      content: (d, h, c, history) => friendlyRecordingRangeForHistory(history, c, false),
+      tooltip: "What versions this probe is actually recorded in. This depends on " +
+               "when the probe was added, removed and its expiry.",
+    }],
     // TODO: overflow should cut off
-    ["description", (d, h, c) => escapeHtml(h.description)],
+    ["description", {
+      content: (d, h, c) => escapeHtml(h.description),
+    }],
   ];
 
   var columns = new Map(rawColumns);
@@ -496,37 +535,37 @@ function renderMeasurements(measurements) {
   var name = probeId => probeId.split("/")[1];
   var sortedProbeKeys = Object.keys(measurements)
                               .sort((a, b) => name(a).toLowerCase().localeCompare(name(b).toLowerCase()));
-  sortedProbeKeys.forEach(id => {
+  for (var id of sortedProbeKeys) {
     var data = measurements[id];
-    for (let [channel, history] of Object.entries(data.history)) {
-      // TODO: Why do we include the following in the filtering stage? Fix this.
-      // Only show channels that we should show now.
-      if ((selectedChannel !== "any") && (channel !== selectedChannel)) {
-        continue;
-      }
-      if (channel == "aurora") {
-        continue;
-      }
-      // When not filtering by channel, it's confusing to show multiple rows for each probe (one for each channel).
-      // The short-term hack here to improve this is to only show the release channel state.
-      // TODO: solve this better.
-      if ((selectedChannel === "any") && (channel !== "release")) {
-        continue;
-      }
-      // Don't show pre-release measurements for the release channel.
-      if (!history[0].optout && (channel == "release") && (selectedChannel !== "any")) {
-        continue;
-      }
 
-      var cells = [...columns.entries()].map(([field, fn]) => {
-        var d = fn(data, history[0], channel, history);
-        return `<td class="search-results-field-${field}">${d}</td>`;
-      });
-      table += `<tr onclick="showDetailView(this); return false;" probeid="${id}" channel="${channel}">`;
-      table += cells.join("");
-      table += `</tr>`;
+    // If a specific channel is selected, skip probes that are not on it.
+    if ((selectedChannel !== "any") && !(selectedChannel in data.history)) {
+      continue;
     }
-  });
+
+    // If a specific channel is selected, use the history from that channel.
+    // If searching on "any" channel, use the first applicable channel for the probe.
+    // Doing this allows us to also see probes whose state hasn't propagated to release yet.
+    var channel = selectedChannel;
+    if (selectedChannel === "any") {
+      channel = ["release", "beta", "nightly"].find(c => c in data.history);
+    }
+    var history = data.history[channel];
+
+    // Don't show pre-release measurements for the release channel.
+    if (!history[0].optout && (channel == "release") && (selectedChannel !== "any")) {
+      continue;
+    }
+
+    // Render entry into a search results row.
+    var cells = [...columns.entries()].map(([field, entry]) => {
+      var d = entry.content(data, history[0], channel, history);
+      return `<td class="search-results-field-${field}" title="${entry.tooltip || ""}">${d}</td>`;
+    });
+    table += `<tr onclick="showDetailView(this); return false;" probeid="${id}" channel="${channel}">`;
+    table += cells.join("");
+    table += `</tr>`;
+  }
 
   table += "</table>";
   items.push(table);
@@ -859,15 +898,19 @@ function showDetailViewForId(probeId, channel=$("#select_channel").val()) {
   $('#detail-recording-type').text(state.optout ? "release" : "prerelease");
   $('#detail-description').text(state.description);
 
-  // Recording range
+  // Recording range and expiry.
   let rangeText = [];
+  let expiryText = [];
   for (let [ch, history] of Object.entries(probe.history)) {
     if ((!history[0].optout && (ch == "release")) || (ch == "aurora")) {
       continue;
     }
+
     rangeText.push(`${ch} ${friendlyRecordingRangeForHistory(history, ch, true)}`);
+    expiryText.push(`${ch} ${friendlyExpiryDescriptionForHistory(history, ch)}`);
   }
   $('#detail-recording-range').html(rangeText.join("<br/>"));
+  $('#detail-expiry').html(expiryText.join("<br/>"));
 
   // Apply dataset infos.
   var datasetInfos = getDatasetInfos(probeId, channel, state);
@@ -900,9 +943,9 @@ function showDetailViewForId(probeId, channel=$("#select_channel").val()) {
     ['high', 'detail-histogram-high', ['histogram']],
     ['n_buckets', 'detail-histogram-bucket-count', ['histogram']],
 
-    ['extra_keys', 'detail-event-methods', ['event']],
-    ['methods', 'detail-event-objects', ['event']],
-    ['objects', 'detail-event-extra-keys', ['event']],
+    ['methods', 'detail-event-methods', ['event']],
+    ['objects', 'detail-event-objects', ['event']],
+    ['extra_keys', 'detail-event-extra-keys', ['event']],
   ];
 
   var pretty = (prop) => {

--- a/index.html
+++ b/index.html
@@ -156,8 +156,11 @@
       <br />
       <table class="table table-sm table-striped table-hover table-bordered border-0">
         <tr><td class="fit pr-2">Type:</td><td id="detail-probe-type" class="grow"></td></tr>
-        <tr><td class="fit pr-2">Population:</td><td id="detail-recording-type" class="grow"></td></tr>
-        <tr id="detail-datasets-row">
+        <tr title="Whether this probe collected on Firefox release or only on prerelease channels.">
+          <td class="fit pr-2">Population:</td><td id="detail-recording-type" class="grow"></td>
+        </tr>
+        <tr id="detail-datasets-row"
+            title="This lists some of the tools or datasets this probe is available in. Note that this is not a complete list.">
           <td class="fit pr-2">Available in:</td><td id="detail-datasets-content" class="grow"></td>
         </tr>
       </table>
@@ -168,15 +171,22 @@
         <tr><td class="fit ml-1">Kind:</td><td id="detail-kind" class="grow"></td></tr>
         <tr><td class="fit pr-2">Keyed:</td><td id="detail-keyed" class="grow"></td></tr>
         <tr><td class="fit pr-2">Bug numbers:</td><td id="detail-bug-numbers" class="grow"></td></tr>
-        <tr><td class="fit pr-2">Recorded in versions:</td><td id="detail-recording-range" class="grow"></td></tr>
+        <tr title="What versions this probe is actually recorded in. This depends on when the probe was added, removed and its expiry.">
+          <td class="fit pr-2">Recorded in versions:</td><td id="detail-recording-range" class="grow"></td>
+        </tr>
         <tr><td class="fit pr-2">Recorded in processes:</td><td id="detail-processes" class="grow"></td></tr>
+        <tr title="The probe will automatically expire in and stop recording in this version. This means that the probe will record at most until the version before that. Note that the code recording it could be removed before that.">
+          <td class="fit pr-2">Expiry:</td><td id="detail-expiry" class="grow"></td>
+        </tr>
         <tr><td class="fit pr-2">Bucket count:</td><td id="detail-histogram-bucket-count" class="grow"></td></tr>
         <tr><td class="fit pr-2">Low:</td><td id="detail-histogram-low" class="grow"></td></tr>
         <tr><td class="fit pr-2">High:</td><td id="detail-histogram-high" class="grow"></td></tr>
         <tr><td class="fit pr-2">Methods:</td><td id="detail-event-methods" class="grow"></td></tr>
         <tr><td class="fit pr-2">Objects:</td><td id="detail-event-objects" class="grow"></td></tr>
         <tr><td class="fit pr-2">Extra keys:</td><td id="detail-event-extra-keys" class="grow"></td></tr>
-        <tr><td class="fit pr-2">C++ guard:</td><td id="detail-cpp-guard" class="grow"></td></tr>
+        <tr title="Some probes have a 'C++ guard' set, which generates a preprocessor statement in Firefox code. This is used to limit probes to record only on some platforms or products.">
+          <td class="fit pr-2">Preprocessor guard:</td><td id="detail-cpp-guard" class="grow"></td>
+        </tr>
       </table>
     </div>
   </div>

--- a/other_fields.json
+++ b/other_fields.json
@@ -776,6 +776,90 @@
       ]
     }
   },
+  "simpleMeasurements/selectProfile": {
+    "name": "selectProfile",
+    "type": "simpleMeasurements",
+    "history": {
+      "all": [
+        {
+          "description": "Timestamp of 'select profile' event.",
+          "bug_numbers": [],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    }
+  },
+  "simpleMeasurements/delayedStartupStarted": {
+    "name": "delayedStartupStarted",
+    "type": "simpleMeasurements",
+    "history": {
+      "all": [
+        {
+          "description": "Timestamp of 'delayed startup started' event.",
+          "bug_numbers": [],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    }
+  },
+  "simpleMeasurements/delayedStartupFinished": {
+    "name": "delayedStartupFinished",
+    "type": "simpleMeasurements",
+    "history": {
+      "all": [
+        {
+          "description": "Timestamp of 'delayed startup finished' event.",
+          "bug_numbers": [],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    }
+  },
+  "simpleMeasurements/blankWindowShown": {
+    "name": "blankWindowShown",
+    "type": "simpleMeasurements",
+    "history": {
+      "all": [
+        {
+          "description": "Timestamp of 'blank window shown' event.",
+          "bug_numbers": [],
+          "details": {
+            "kind": "number"
+          },
+          "expiry_version": "never",
+          "optout": true,
+          "revisions": {
+            "firstVersion": "42",
+            "last": "latest"
+          }
+        }
+      ]
+    }
+  },
   "simpleMeasurements/main": {
     "name": "main",
     "type": "simpleMeasurements",


### PR DESCRIPTION
Merge in latest changes from mozilla/telemetry-dashboard/, the probe-dictionary directionary. This is to prepare us for migrating this repository to react.

- Fix search results display of probes not yet on release (mozilla/telemetry-dashboard#560)
- Refactor document ready handlers (mozilla/telemetry-dashboard#555)
- Fix expiry handling in probe dictionary (mozilla/telemetry-dashboard#561)
- Add some tooltips to probe dictionary fields (mozilla/telemetry-dashboard#566)
- Fix probe-dictionary event details (mozilla/telemetry-dashboard#610)
- Fix for issue: Missing simple measures in probe dictionary (mozilla/telemetry-dashboard#609)