### PR TITLE
(fixes #24) add basic DXR and searchfox links

### DIFF
--- a/src/components/probeDetails.jsx
+++ b/src/components/probeDetails.jsx
@@ -9,7 +9,9 @@ import {
 
 // Used quite heavily in getDatasetInfo() below.
 const getNewTabLink = (link, label) => (
-  <a href={link} rel="noopener noreferrer" target="_blank">{label}</a>
+  <React.Fragment>
+    <a href={link} rel="noopener noreferrer" target="_blank"><i className="fa fa-external-link" /> {label}</a>
+  </React.Fragment>
 );
 
 // ported from explore.js
@@ -314,6 +316,12 @@ class ProbeDetails extends Component {
           <br />
           <table className="table table-sm table-striped table-hover table-bordered border-0">
             <tbody>
+              <tr>
+                <td className="fit pr-2">Find in:</td>
+                <td className="grow">
+                  {getNewTabLink(`https://dxr.mozilla.org/mozilla-central/search?q=${probe.name}`, 'DXR')},{' '}
+                  {getNewTabLink(`https://searchfox.org/mozilla-central/search?q=${probe.name}`, 'Searchfox')}</td>
+              </tr>
               <tr>
                 <td className="fit pr-2">Bug numbers:</td>
                 <td id="detail-bug-numbers" className="grow">

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -282,3 +282,8 @@ th {
   cursor: default;
   pointer-events: none;
 }
+
+#detail-body i.fa {
+  font-size: 13px;
+  font-weight: 600;
+}


### PR DESCRIPTION
I fully expect this to require a few iterations - this one just fills in the q param on DXR + searchfox.

<img width="366" alt="image" src="https://user-images.githubusercontent.com/391260/73789053-b4ddf180-4763-11ea-9f2e-e9aad1e47193.png">


