### PR TITLE
Differentiate keyed probes from regular probes

### DIFF
--- a/src/components/probeDetails.jsx
+++ b/src/components/probeDetails.jsx
@@ -124,8 +124,9 @@ function getDatasetInfo(revisions, channelInfo, probeId, probe, channel, state) 
       datasetText = getNewTabLink(dataDocs[dataset], dataset);
     }
     if (state.details.record_in_processes) {
+      const isKeyed = probe["history"][channel][0]["details"]["keyed"];
       state.details.record_in_processes.forEach(process => {
-        let name = <React.Fragment>{code(<React.Fragment>payload.processes.{(process === 'main') ? 'parent' : process}.scalars.{snakeCase(probe.name)}</React.Fragment>)}</React.Fragment>;
+        let name = <React.Fragment>{code(<React.Fragment>payload.processes.{(process === 'main') ? 'parent' : process}.{isKeyed ? 'keyed_scalars' : 'scalars'}.{snakeCase(probe.name)}</React.Fragment>)}</React.Fragment>;
         datasetInfo.push(<React.Fragment>{stmoLink}: in {datasetText} as {name}</React.Fragment>);
       });
     }
@@ -138,12 +139,13 @@ function getDatasetInfo(revisions, channelInfo, probeId, probe, channel, state) 
       datasetText = getNewTabLink(dataDocs[dataset], dataset);
     }
     if (state.details.record_in_processes) {
+      const isKeyed = probe["history"][channel][0]["details"]["keyed"];
       state.details.record_in_processes.forEach(process => {
         let name;
         if (process === 'main') {
-          name = <React.Fragment>{code(<React.Fragment>payload.histograms.{snakeCase(probe.name)}</React.Fragment>)}</React.Fragment>;
+          name = <React.Fragment>{code(<React.Fragment>payload.{isKeyed ? 'keyed_histograms' : 'histograms'}.{snakeCase(probe.name)}</React.Fragment>)}</React.Fragment>;
         } else {
-          name = <React.Fragment>{code(<React.Fragment>payload.processes.{(process === 'main') ? 'parent' : process}.histograms.{snakeCase(probe.name)}</React.Fragment>)}</React.Fragment>;
+          name = <React.Fragment>{code(<React.Fragment>payload.processes.{(process === 'main') ? 'parent' : process}.{isKeyed ? 'keyed_histograms' : 'histograms'}.{snakeCase(probe.name)}</React.Fragment>)}</React.Fragment>;
         }
         datasetInfo.push(<React.Fragment>{stmoLink}: in {datasetText} as {name}</React.Fragment>);
       });

--- a/src/components/probeDetails.jsx
+++ b/src/components/probeDetails.jsx
@@ -62,7 +62,9 @@ function getProbeDocumentationURI(type) {
   const links = {
     environment: sourceDocs + 'data/environment.html',
     histogram: sourceDocs + 'collection/histograms.html',
+    'keyed histogram': sourceDocs + 'collection/histograms.html#keyed-histograms',
     scalar: sourceDocs + 'collection/scalars.html',
+    'keyed scalar': sourceDocs + 'collection/scalars.html#keyed-scalars',
     event: sourceDocs + 'collection/events.html',
   };
 
@@ -281,7 +283,7 @@ class ProbeDetails extends Component {
               <tr>
                 <td className="fit pr-2">Type:</td>
                 <td id="detail-probe-type" className="grow">
-                  <a href={getProbeDocumentationURI(probe.type)}>{probe["detailed_type"]}</a>
+                  <a href={getProbeDocumentationURI(probe["detailed_type"])}>{probe["detailed_type"]}</a>
                 </td>
               </tr>
               <tr title="Whether this probe collected on Firefox release or only on prerelease channels.">

--- a/src/components/probeDetails.jsx
+++ b/src/components/probeDetails.jsx
@@ -281,7 +281,7 @@ class ProbeDetails extends Component {
               <tr>
                 <td className="fit pr-2">Type:</td>
                 <td id="detail-probe-type" className="grow">
-                  <a href={getProbeDocumentationURI(probe.type)}>{probe.type}</a>
+                  <a href={getProbeDocumentationURI(probe.type)}>{probe["detailed_type"]}</a>
                 </td>
               </tr>
               <tr title="Whether this probe collected on Firefox release or only on prerelease channels.">
@@ -353,7 +353,7 @@ class ProbeDetails extends Component {
               {getExtraProbeDetails(probe, probeInfo).map(detail => (
                 <tr key={detail.label}>
                   <td className="fit pr-2">{detail.label}:</td>
-                  <td className="grow">{detail.content}</td>
+                  <td className="grow">{detail.content.toString()}</td>
                 </tr>
                 ))}
               {categoryLabels && (

--- a/src/components/searchResultsRow.jsx
+++ b/src/components/searchResultsRow.jsx
@@ -34,7 +34,7 @@ const SearchResultsRow = ({
   return (
     <tr onClick={() => doExposeProbeDetails(probeId, rowData)}>
       <td className="search-results-field-name">{rowData.name}</td>
-      <td className="search-results-field-type">{rowData.type}</td>
+      <td className="search-results-field-type">{rowData["detailed_type"]}</td>
       <td className="search-results-field-population"
           title="Whether this probe collected on Firefox release or only on prerelease channels.">
         {getPopulation(history)}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -178,6 +178,14 @@ class Main extends Component {
           history = history.filter(m => m.optout);
         }
 
+        // Add a detailed type to differentiate between regular and keyed probes
+        if (history[0]["details"]["keyed"]) {
+          // Ensure that we only add the word "keyed" once, since React lifecycle can call this method multiple times
+          data["detailed_type"] = data["type"].includes("keyed") ? data["type"] : `keyed ${data["type"]}`
+        } else {
+          data["detailed_type"] = data["type"]
+        }
+
         // Filter for version constraint.
         if (selectedVersion !== 'any') {
           history = history.filter(m => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -179,12 +179,7 @@ class Main extends Component {
         }
 
         // Add a detailed type to differentiate between regular and keyed probes
-        if (history[0]["details"]["keyed"]) {
-          // Ensure that we only add the word "keyed" once, since React lifecycle can call this method multiple times
-          data["detailed_type"] = data["type"].includes("keyed") ? data["type"] : `keyed ${data["type"]}`
-        } else {
-          data["detailed_type"] = data["type"]
-        }
+        data["detailed_type"] = history[0]["details"]["keyed"] ? `keyed ${data["type"]}` : data["type"]
 
         // Filter for version constraint.
         if (selectedVersion !== 'any') {


### PR DESCRIPTION
Make it more clear when a probe is keyed and get the correct BigQuery tables for keyed probes. Also fixes #127, #125, #121.