### PR TITLE
Enable OpenSSL legacy providers in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "throttle-debounce": "^2.1.0"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "react-scripts --openssl-legacy-provider start",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "cypress open",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Otherwise we see the docker build failing with a
`ERR_OSSL_EVP_UNSUPPORTED` error.

node v17 updated to OpenSSL 3.0, which hides some old and deprecated algorithms.
see details at https://nodejs.org/en/blog/release/v17.0.0/#openssl-3-0